### PR TITLE
Rebuild StoryEven from scratch with full feature implementation

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,171 +1,527 @@
-::root {
-    --placeholder-color: black;
+/* ============================================================
+   StoryEven — Main Stylesheet
+   ============================================================ */
+
+/* ----- Reset & Custom Properties ----- */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
 }
 
-@media  (max-width : 400px) {
-   #main-title {
-       font-size: 15vmin !important;
-   };
-   .the-button {
-    font-size: 10px !important;
-   }
+:root {
+  --c-bg:         #ffffff;
+  --c-text:       #0a0a0a;
+  --c-muted:      #6b6b6b;
+  --c-subtle:     #f0f0f0;
+  --c-border:     #ddd;
+  --c-accent:     #F5C518;  /* yellow — matches mockup button */
+  --c-good:       #1e7e1e;  /* green  — ideal section  */
+  --c-long:       #c0392b;  /* red    — too long        */
+  --c-short:      #d35400;  /* orange — too short       */
+
+  --font-serif:  'Playfair Display', Georgia, 'Times New Roman', serif;
+  --font-sans:   'Inter', system-ui, -apple-system, sans-serif;
+
+  --max-w: 740px;
+  --pad-x: 1.5rem;
+  --radius: 4px;
+}
+
+/* ----- Base ----- */
+html {
+  font-size: 16px;
+  -webkit-text-size-adjust: 100%;
+  scroll-behavior: smooth;
 }
 
 body {
-    font-size: 16px;
-    font-family: 'Playfair Display', serif;
-    
-}
-header{
-    text-align: right;
-}
-footer{
-    text-align: center;
+  background: var(--c-bg);
+  color: var(--c-text);
+  font-family: var(--font-sans);
+  line-height: 1.6;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
-
-#main-title {
-
-    font-style: normal;
-    font-weight: 900;
-    font-size: 4rem;
-
-    text-transform: capitalize;
-
+a {
+  color: inherit;
 }
 
-#uvp {
-
-
-    font-style: normal;
-    font-weight: 900;
-    font-size: 36.65px;
-
-    /* identical to box height */
-
-    text-transform: capitalize;
+/* ============================================================
+   HEADER
+   ============================================================ */
+header {
+  border-bottom: 1px solid var(--c-border);
+  padding: 0.875rem var(--pad-x);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
 }
 
-h3 {
-    font-family: Roboto;
-    font-style: normal;
-    font-weight: normal;
-    font-size: 22.65px;
-
-    text-transform: capitalize;
+.logo {
+  font-family: var(--font-serif);
+  font-weight: 900;
+  font-size: 1.2rem;
+  text-decoration: none;
+  letter-spacing: -0.02em;
+  color: var(--c-text);
 }
 
-.parent {
-    display: grid;
-    grid-template-columns: repeat(5, 1fr);
-    grid-template-areas: "head head"
-    "main main"
-    "foot foot";
-    grid-column-gap: 0px;
-    grid-row-gap: 50px;
+.header-links {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
 }
 
-
-
-
-.div1 {
-    grid-area: 1 / 2 / 2 / 5;
+.share-link {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--c-muted);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: color 0.15s, border-color 0.15s;
 }
 
-.div2 {
-    grid-area: 2 / 2 / 3 / 5;
+.share-link:hover {
+  color: var(--c-text);
+  border-color: var(--c-text);
 }
 
-.div3 {
-    grid-area: 3 / 2 / 4 / 5;
+/* ============================================================
+   MAIN
+   ============================================================ */
+main {
+  flex: 1;
+  max-width: var(--max-w);
+  width: 100%;
+  margin: 0 auto;
+  padding: 0 var(--pad-x);
 }
 
-
-
-#big-text {
-    max-width: 60vw;
-    margin-top: 20px;
-    margin:0 auto;
-    display:block;
-   
-
+/* ============================================================
+   HERO
+   ============================================================ */
+.hero {
+  padding: 3.5rem 0 2rem;
+  text-align: center;
 }
 
-::-webkit-input-placeholder { /* Chrome/Opera/Safari */
-    color: var(--placeholder-color);
-    padding: 10px 0px 0px 10px
-  }
-  ::-moz-placeholder { /* Firefox 19+ */
-    color:var(--placeholder-color);
-    padding: 10px 0px 0px 10px
-  }
-  
-  :-ms-input-placeholder { /* IE 10+ */
-    color:var(--placeholder-color);
-    padding: 10px 0px 0px 10px
-  }
-  
-  :-moz-placeholder { /* Firefox 18- */
-    color:var(--placeholder-color);
-    padding: 10px 0px 0px 10px
-  }
-  
-
-.the-button {
-   
-    box-shadow: 4px 8px 0px rgba(1, 1, 1, 1);
-    display: inline-block;
-    cursor: pointer;
-    color: rgba(0, 0, 0, 0.89);
-    
-    padding: 6px 15px;
-    text-decoration: none;
-    width: fit-content;
-    height: fit-content;
-
+.hero h1 {
+  font-family: var(--font-serif);
+  font-weight: 900;
+  font-size: clamp(1.85rem, 5.5vw, 3.2rem);
+  line-height: 1.12;
+  letter-spacing: -0.025em;
+  margin-bottom: 1.25rem;
 }
 
-
-.the-button:active {
-    position: relative;
-    top: 1px;
+.hero-sub {
+  color: var(--c-muted);
+  font-size: 1.05rem;
+  line-height: 1.5;
+  margin-bottom: 0.3rem;
 }
 
-.the-button:hover {
-    color: rgba(0, 0, 0);
+.divider {
+  border: none;
+  border-top: 1px solid var(--c-border);
+  width: 180px;
+  margin: 1.75rem auto 0;
 }
 
-#big-text::-webkit-resizer {
-    background-color: #000000;
+/* ============================================================
+   INPUT SECTION
+   ============================================================ */
+.input-section {
+  margin-bottom: 2.5rem;
 }
 
-.input-field {
-    display: flex;
-    flex-direction: column;
-}
-
-::-webkit-resizer {
-    background-color: lightgrey;
+.input-label {
+  display: block;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--c-muted);
+  margin-bottom: 0.5rem;
 }
 
 textarea {
-    box-shadow: inset 1px 2px 5px #000;
-    border-radius: 3px;
-    width: 50vw;
+  display: block;
+  width: 100%;
+  padding: 1.1rem 1.25rem;
+  border: 2px solid var(--c-text);
+  border-radius: 0;
+  font-family: var(--font-serif);
+  font-size: 1rem;
+  font-style: italic;
+  line-height: 1.7;
+  color: var(--c-text);
+  background: #fafafa;
+  resize: vertical;
+  min-height: 200px;
+  box-shadow: 5px 5px 0 var(--c-text);
+  transition: box-shadow 0.12s ease;
 }
 
-canvas {
-    width: 60vw;
-    max-width: 60vw;
-    margin-top: 20px;
-    margin:0 auto;
-    display:block;
-    text-align:center;
+textarea:focus {
+  outline: none;
+  box-shadow: 7px 7px 0 var(--c-text);
 }
 
-.btn {
-    max-width: 50vw;
-    margin:20px auto;
-    display:block;
-    text-align:center;
+textarea::placeholder {
+  color: #aaa;
+  font-style: italic;
+}
+
+.input-hint {
+  margin-top: 0.6rem;
+  font-size: 0.78rem;
+  color: var(--c-muted);
+}
+
+.input-hint code {
+  background: var(--c-subtle);
+  padding: 0.1em 0.35em;
+  border-radius: 2px;
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 0.85em;
+}
+
+.input-hint kbd {
+  background: var(--c-subtle);
+  border: 1px solid var(--c-border);
+  border-bottom-width: 2px;
+  padding: 0.05em 0.3em;
+  border-radius: 3px;
+  font-size: 0.8em;
+  font-family: var(--font-sans);
+}
+
+.input-actions {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.875rem;
+  margin-top: 1.25rem;
+}
+
+/* ============================================================
+   BUTTONS
+   ============================================================ */
+.btn-primary {
+  background: var(--c-accent);
+  color: var(--c-text);
+  border: 2.5px solid var(--c-text);
+  border-radius: 100px;
+  padding: 0.65rem 1.75rem;
+  font-family: var(--font-sans);
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 4px 4px 0 var(--c-text);
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+  white-space: nowrap;
+  user-select: none;
+}
+
+.btn-primary:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 5px 5px 0 var(--c-text);
+}
+
+.btn-primary:active {
+  transform: translate(2px, 2px);
+  box-shadow: 2px 2px 0 var(--c-text);
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--c-muted);
+  border: 1.5px solid var(--c-border);
+  border-radius: 100px;
+  padding: 0.65rem 1.25rem;
+  font-family: var(--font-sans);
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+  white-space: nowrap;
+  user-select: none;
+}
+
+.btn-ghost:hover {
+  color: var(--c-text);
+  border-color: var(--c-text);
+}
+
+/* ============================================================
+   RESULTS SECTION
+   ============================================================ */
+.results-section[hidden] {
+  display: none;
+}
+
+.results-section {
+  padding-bottom: 3rem;
+}
+
+/* --- Stats Bar --- */
+.stats-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.5rem;
+  align-items: center;
+  background: var(--c-subtle);
+  border-left: 4px solid var(--c-text);
+  padding: 0.75rem 1rem;
+  margin-bottom: 1.75rem;
+  font-size: 0.85rem;
+}
+
+.stats-bar .stat {
+  color: var(--c-muted);
+}
+
+.stats-bar .stat strong {
+  color: var(--c-text);
+  font-weight: 700;
+}
+
+.stat-score strong {
+  color: var(--c-good);
+}
+
+.stat-score.score-warn strong {
+  color: var(--c-short);
+}
+
+.stat-score.score-bad strong {
+  color: var(--c-long);
+}
+
+/* ============================================================
+   TIMELINE
+   ============================================================ */
+.timeline-wrap {
+  margin: 0.5rem 0 2.25rem;
+  overflow-x: auto;
+  overflow-y: visible;
+  padding-bottom: 0.5rem;
+}
+
+.timeline-svg {
+  display: block;
+  width: 100%;
+  min-width: 380px;
+  overflow: visible;
+}
+
+/* ============================================================
+   NO HEADINGS MESSAGE
+   ============================================================ */
+.no-headings-msg {
+  text-align: center;
+  padding: 2rem 1.5rem;
+  background: #fffbec;
+  border: 2px dashed #e5c04e;
+  border-radius: var(--radius);
+  margin-bottom: 2rem;
+}
+
+.no-headings-msg h3 {
+  font-family: var(--font-serif);
+  font-weight: 700;
+  font-size: 1.2rem;
+  margin-bottom: 0.75rem;
+}
+
+.no-headings-msg p {
+  font-size: 0.925rem;
+  color: var(--c-muted);
+  line-height: 1.7;
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+.no-headings-msg code {
+  background: rgba(0,0,0,0.07);
+  padding: 0.1em 0.35em;
+  border-radius: 2px;
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 0.85em;
+  color: var(--c-text);
+}
+
+/* ============================================================
+   SECTIONS LIST
+   ============================================================ */
+.sections-title {
+  font-family: var(--font-serif);
+  font-weight: 700;
+  font-size: 1.15rem;
+  padding-bottom: 0.5rem;
+  margin-bottom: 1rem;
+  border-bottom: 2px solid var(--c-text);
+}
+
+.sections-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+}
+
+.section-card {
+  padding: 1rem 1.1rem;
+  border: 1.5px solid var(--c-border);
+  border-left-width: 4px;
+  border-radius: var(--radius);
+  background: #fff;
+}
+
+.section-card--good  { border-left-color: var(--c-good);  }
+.section-card--long  { border-left-color: var(--c-long);  }
+.section-card--short { border-left-color: var(--c-short); }
+.section-card--intro { border-left-color: var(--c-border); }
+
+.section-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.section-card-title {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.heading-badge {
+  flex-shrink: 0;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: var(--c-text);
+  color: #fff;
+  padding: 0.18em 0.5em;
+  border-radius: 2px;
+}
+
+.heading-badge--intro {
+  background: var(--c-muted);
+}
+
+.heading-text {
+  font-family: var(--font-serif);
+  font-weight: 700;
+  font-size: 0.95rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.section-meta {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.2rem;
+}
+
+.word-count {
+  font-weight: 700;
+  font-size: 0.875rem;
+  white-space: nowrap;
+}
+
+.word-count--good  { color: var(--c-good);  }
+.word-count--long  { color: var(--c-long);  }
+.word-count--short { color: var(--c-short); }
+.word-count--intro { color: var(--c-muted); }
+
+.quality-hint {
+  font-size: 0.72rem;
+  color: var(--c-muted);
+  white-space: nowrap;
+}
+
+.section-preview {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: 0.875rem;
+  line-height: 1.55;
+  color: var(--c-muted);
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid #efefef;
+}
+
+/* ============================================================
+   FOOTER
+   ============================================================ */
+footer {
+  border-top: 1px solid var(--c-border);
+  padding: 1.5rem var(--pad-x);
+  text-align: center;
+  color: var(--c-muted);
+  font-size: 0.78rem;
+  margin-top: auto;
+}
+
+footer a {
+  color: var(--c-muted);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+footer a:hover {
+  color: var(--c-text);
+}
+
+/* ============================================================
+   RESPONSIVE
+   ============================================================ */
+@media (max-width: 560px) {
+  .hero h1 {
+    font-size: 1.75rem;
+  }
+
+  .hero {
+    padding-top: 2rem;
+  }
+
+  .stats-bar {
+    gap: 0.4rem 1rem;
+    font-size: 0.8rem;
+  }
+
+  .section-card-header {
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .section-meta {
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+  }
+}
+
+@media (max-width: 400px) {
+  .hero h1 {
+    font-size: 1.5rem;
+  }
+
+  .btn-primary {
+    font-size: 0.9rem;
+    padding: 0.6rem 1.35rem;
+  }
 }

--- a/index.html
+++ b/index.html
@@ -1,91 +1,63 @@
 <!DOCTYPE html>
-<html>
-
+<html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width,initial-scale=1">
-    <title>StoryEven | Easily Distribute Your Document Between Headings</title>
-    <meta name="author" content="George Nurijanian">
-    <meta name="description" content="Write text with StoryEven and it will tell you when to add a heading.">
-    <meta name="keywords" content="storyeven, blogging, seo, writing, copywriting">
-    <!-- Google Tag Manager -->
-    <script>
-        (function (w, d, s, l, i) {
-            w[l] = w[l] || [];
-            w[l].push({
-                'gtm.start': new Date().getTime(),
-                event: 'gtm.js'
-            });
-            var f = d.getElementsByTagName(s)[0],
-                j = d.createElement(s),
-                dl = l != 'dataLayer' ? '&l=' + l : '';
-            j.async = true;
-            j.src =
-                'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
-            f.parentNode.insertBefore(j, f);
-        })(window, document, 'script', 'dataLayer', 'GTM-NHG97XV');
-    </script>
-    <!-- End Google Tag Manager -->
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js" async="true"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/markdown-it/11.0.0/markdown-it.min.js"></script>
-
-    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="css/main.css">
-    <!-- Hotjar Tracking Code for https://storyeven.xyz -->
-<script>
-    (function(h,o,t,j,a,r){
-        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-        h._hjSettings={hjid:1957453,hjsv:6};
-        a=o.getElementsByTagName('head')[0];
-        r=o.createElement('script');r.async=1;
-        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-        a.appendChild(r);
-    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
-</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>StoryEven — Evenly Distribute Your Document Between Headings</title>
+  <meta name="description" content="Analyse your document's heading distribution. StoryEven visualises word counts between headings so you can spot sections that are too long or too short.">
+  <meta name="author" content="George Nurijanian">
+  <meta name="keywords" content="storyeven, writing, headings, readability, seo, copywriting, document structure">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700;900&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/main.css">
 </head>
-
 <body>
-    <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NHG97XV" height="0" width="0"
-            style="display:none;visibility:hidden"></iframe></noscript>
-    <!-- End Google Tag Manager (noscript) -->
-    <header>
-        
-<a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false">Share on Twitter</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-    </header>
-   
-    
-    <div class="parent">
-        <div class="div1">
-            <h1 id='main-title'>StoryEven</h1>
-            <h2 id='uvp'>Easily Distribute Your Document Between Headings</h2>
-            <h3>Make your document more scannable. Add headings at each ~ 250 words.</h3>
 
-        </div>
-        <div class="div2">
-            <div class="input-field">
-                <form id="target">
-                    <h4><label for="big-text">Paste your text below (min ~ 250 words)</label></h4>
+  <header>
+    <a class="logo" href="/" aria-label="StoryEven home">StoryEven</a>
+    <nav class="header-links">
+      <a href="https://twitter.com/intent/tweet?text=StoryEven+%E2%80%94+distribute+your+document+between+headings+evenly&url=https://storyeven.xyz" target="_blank" rel="noopener noreferrer" class="share-link">Share on Twitter</a>
+    </nav>
+  </header>
 
-                    <textarea autofocus rows=20 type="text" id="big-text" name="big-text" required maxlength="30000"
-                        placeholder="I met a traveller from an antique land...
-                    "></textarea>
-                    <div class='btn'>
-                        <input class="the-button" type="submit" value="Make My Text Better" ></div>
-                </form>
-            </div>
-        </div>
-        <div class="div3">
-            <div id="markdown-display"></div>
-            <div id="pointer"><span class="circle"></span></div>
-            <canvas width="100" height="100" id="the-line"></canvas>
-        </div>
-    </div>
-<footer>
-    <small>&copy; Copyright 2020, George Nurijanian</small>
-</footer>
+  <main>
+
+    <!-- Hero -->
+    <section class="hero">
+      <h1>Evenly Distribute Your<br>Document Between Headings.</h1>
+      <p class="hero-sub">Visualise the whole text on a timeline.</p>
+      <p class="hero-sub">Delete and re-write long parts and make your stories more engaging.</p>
+      <hr class="divider">
+    </section>
+
+    <!-- Input -->
+    <section class="input-section" aria-label="Text input">
+      <label for="text-input" class="input-label">Copy-paste your text below</label>
+      <textarea
+        id="text-input"
+        rows="12"
+        placeholder="I am forced into speech because men of science have refused to follow my advice without knowing why. It is altogether against my will that I tell my reasons for opposing this contemplated invasion of the antarctic — with its vast fossil hunt and its wholesale boring and melting of the ancient ice caps. And I am the more reluctant because my warning may be in vain."
+        spellcheck="true"
+        aria-label="Paste your document here. Use markdown headings like ## Section Title to mark headings."
+      ></textarea>
+      <p class="input-hint">Use <code>## Heading</code> markdown syntax &nbsp;·&nbsp; <kbd>Ctrl</kbd>+<kbd>Enter</kbd> to analyse</p>
+      <div class="input-actions">
+        <button id="analyze-btn" class="btn-primary" type="button">Even Things Out</button>
+        <button id="clear-btn" class="btn-ghost" type="button">Clear</button>
+      </div>
+    </section>
+
+    <!-- Results (filled by JS) -->
+    <section class="results-section" id="results" aria-live="polite" hidden>
+    </section>
+
+  </main>
+
+  <footer>
+    <small>&copy; 2024 George Nurijanian &nbsp;·&nbsp; <a href="https://github.com/gnurio/storyeven" target="_blank" rel="noopener noreferrer">GitHub</a></small>
+  </footer>
+
+  <script src="js/script.js"></script>
 </body>
-<script src="js/script.js"></script>
-
-
 </html>

--- a/js/script.js
+++ b/js/script.js
@@ -1,78 +1,489 @@
-const md = window.markdownit();// trying to use Markdown-it here
-//const tokenize = new Tokenizer(); // but Tokenize-text doesn't have a link I can paste in HTML, so I need to use it here
+'use strict';
 
+/* ============================================================
+   StoryEven — Core Application
+   ============================================================
+   Features:
+   - Parse markdown headings (# ## ### …) from pasted text
+   - Count words in each section between headings
+   - Visualise sections on a proportional SVG timeline
+   - Colour-code by quality: 🔥 ideal (~250 w), ✕ too long, ✕ too short
+   - Render section cards with heading, word count, and preview
+   ============================================================ */
 
-const drawLine = () => {
+// ── Constants ──────────────────────────────────────────────
+const TARGET_WORDS = 250;   // ideal words per section
+const MIN_OK       = 150;   // below this → too short
+const MAX_OK       = 350;   // above this → too long
 
-    let c = document.getElementById('the-line');
-    let ctx = c.getContext("2d");
-    ctx.beginPath();
-    ctx.moveTo(0, 0);
-    ctx.lineTo(400, 0);
-    ctx.lineWidth = 2;
-    ctx.strokeStyle = '#747e86';
-    ctx.stroke();
-}
+const COLOR_GOOD  = '#1e7e1e';
+const COLOR_LONG  = '#c0392b';
+const COLOR_SHORT = '#d35400';
+const COLOR_INTRO = '#888';
 
-const activateLine = () => {
+const SVG_NS = 'http://www.w3.org/2000/svg';
 
-    let c = document.getElementById('the-line');
-    let ctx = c.getContext("2d");
-    ctx.beginPath();
-    ctx.moveTo(0, 0);
-    ctx.lineTo(400, 0);
-    ctx.lineWidth = 5;
-    ctx.strokeStyle = '#000000';
-    ctx.stroke();
-}
+// ── Markdown Parser ────────────────────────────────────────
+/**
+ * Parse text into sections. Each section may have a markdown heading
+ * (e.g. "## My Section") and a body of paragraph text.
+ *
+ * @param  {string} text
+ * @returns {{ heading: { level: number, text: string } | null, content: string }[]}
+ */
+function parseMarkdown(text) {
+  const lines = text.split('\n');
+  const sections = [];
 
+  let currentHeading = null;
+  let currentLines   = [];
 
-const chunkText = (str, n) => {
-    let ret = [];
-    let i;
-    let len;
-
-    for (i = 0, len = str.length; i < len; i += n) {
-        ret.push(str.substr(i, n))
+  function flush() {
+    const content = currentLines.join('\n').trim();
+    if (content || currentHeading !== null) {
+      sections.push({ heading: currentHeading, content });
     }
-    return ret
+  }
+
+  for (const line of lines) {
+    const m = line.match(/^(#{1,6})\s+(.+)$/);
+    if (m) {
+      flush();
+      currentHeading = { level: m[1].length, text: m[2].trim() };
+      currentLines   = [];
+    } else {
+      currentLines.push(line);
+    }
+  }
+
+  flush();
+  return sections;
 }
 
-const chunkTextArr = (arr, n) => {
-    let newArr = arr.slice();
-    let idx = n;
-      while(idx <= newArr.length){
-        newArr.splice(idx, 0,'\n# Add a heading here\n');
-        idx += n + 1;
-         }
-      return newArr.join(' ');
-    };
-//TODO: Recognize end of sentences and paragraphs
+// ── Word Counting & Quality ────────────────────────────────
+/**
+ * Count words in a string.
+ */
+function countWords(str) {
+  if (!str.trim()) return 0;
+  return str.trim().split(/\s+/).length;
+}
 
-drawLine();
+/**
+ * Return quality tier for a word count.
+ * @returns {'good'|'long'|'short'|'intro'}
+ */
+function getQuality(wordCount, isIntro) {
+  if (isIntro) return 'intro';
+  if (wordCount >= MIN_OK && wordCount <= MAX_OK) return 'good';
+  if (wordCount > MAX_OK) return 'long';
+  return 'short';
+}
 
+// ── Build Processed Sections ───────────────────────────────
+/**
+ * Build a processed sections array with word counts and quality tiers.
+ */
+function buildSections(text) {
+  const raw = parseMarkdown(text);
 
-$(document).ready(function () {
-    $("#target").submit(function (event) {
-        event.preventDefault();
-        let area = $("#big-text").val();
-        let splitText = area.split(" ");
-        
-        let chunks = chunkTextArr(splitText, 250);
-        
-        let len = splitText.length;
-        let mkdownChunks = md.render(chunks);
+  return raw
+    .map((s, i) => {
+      const wordCount = countWords(s.content);
+      const isIntro   = s.heading === null;
+      return {
+        heading:   s.heading,
+        content:   s.content,
+        wordCount,
+        quality:   getQuality(wordCount, isIntro),
+        isIntro,
+      };
+    })
+    // Drop completely empty intro (nothing before first heading)
+    .filter(s => s.heading !== null || s.wordCount > 0);
+}
 
-        if (len <= 250) {
-            $("#markdown-display").text("Not long enough. Once you get to ~ 250 words, try me again!")
-        } else {
-            $("#markdown-display").html(mkdownChunks);
-            activateLine();
+// ── Stats ──────────────────────────────────────────────────
+function computeStats(sections) {
+  const totalWords      = sections.reduce((n, s) => n + s.wordCount, 0);
+  const headedSections  = sections.filter(s => !s.isIntro);
+  const goodCount       = headedSections.filter(s => s.quality === 'good').length;
+  const score           = headedSections.length > 0
+    ? Math.round((goodCount / headedSections.length) * 100)
+    : null;
 
-        }
+  return {
+    totalWords,
+    headedCount:  headedSections.length,
+    totalCount:   sections.length,
+    score,
+    goodCount,
+  };
+}
 
+// ── SVG Helpers ────────────────────────────────────────────
+function svgEl(tag, attrs, text) {
+  const e = document.createElementNS(SVG_NS, tag);
+  if (attrs) {
+    for (const [k, v] of Object.entries(attrs)) {
+      e.setAttribute(k, String(v));
+    }
+  }
+  if (text != null) e.textContent = String(text);
+  return e;
+}
+
+// ── Timeline ───────────────────────────────────────────────
+/**
+ * Draw the proportional SVG timeline.
+ *
+ * Layout (per headed section):
+ *   [H2]   ← heading level label (above line)
+ *    ○     ← circle marker on line (at START of section)
+ *  250w    ← word count (below line, coloured)
+ *   🔥     ← quality indicator
+ *
+ * Spacing between circles is proportional to word count of each section.
+ */
+function drawTimeline(sections, svgEl_root) {
+  svgEl_root.innerHTML = '';
+
+  const totalWords    = sections.reduce((n, s) => n + s.wordCount, 0);
+  const headedSects   = sections.filter(s => !s.isIntro);
+  if (totalWords === 0 || headedSects.length === 0) return;
+
+  // Dimensions
+  const containerW = svgEl_root.getBoundingClientRect().width || 680;
+  const PAD_L      = 50;
+  const PAD_R      = 50;
+  const LINE_W     = containerW - PAD_L - PAD_R;
+  const LINE_Y     = 68;
+  const SVG_H      = 155;
+  const R          = 15;  // circle radius
+
+  svgEl_root.setAttribute('viewBox', `0 0 ${containerW} ${SVG_H}`);
+  svgEl_root.style.height = `${SVG_H}px`;
+
+  // ── Build position data ──
+  // Circle x = cumulative words BEFORE this section (proportional to total)
+  let cumWords = 0;
+  const positioned = sections.map(section => {
+    const x     = PAD_L + (cumWords / totalWords) * LINE_W;
+    const endX  = PAD_L + ((cumWords + section.wordCount) / totalWords) * LINE_W;
+    cumWords   += section.wordCount;
+    return { section, x, endX };
+  });
+
+  // ── Base grey line ──
+  svgEl_root.appendChild(svgEl('line', {
+    x1: PAD_L, y1: LINE_Y,
+    x2: PAD_L + LINE_W, y2: LINE_Y,
+    stroke: '#ccc',
+    'stroke-width': 6,
+    'stroke-linecap': 'round',
+  }));
+
+  // ── Coloured segment overlays (per section) ──
+  for (const { section, x, endX } of positioned) {
+    if (section.isIntro || endX - x < 1) continue;
+    const color = qualityColor(section.quality);
+    svgEl_root.appendChild(svgEl('line', {
+      x1: x,    y1: LINE_Y,
+      x2: endX, y2: LINE_Y,
+      stroke: color,
+      'stroke-width': 6,
+      'stroke-linecap': 'butt',
+      opacity: 0.35,
+    }));
+  }
+
+  // ── Black hairline on top ──
+  svgEl_root.appendChild(svgEl('line', {
+    x1: PAD_L, y1: LINE_Y,
+    x2: PAD_L + LINE_W, y2: LINE_Y,
+    stroke: '#000',
+    'stroke-width': 3,
+    'stroke-linecap': 'round',
+    opacity: 0.18,
+  }));
+
+  // ── Heading markers ──
+  for (const { section, x } of positioned) {
+    if (section.isIntro) continue;
+
+    const color = qualityColor(section.quality);
+
+    // Heading level label above circle
+    svgEl_root.appendChild(svgEl('text', {
+      x, y: LINE_Y - R - 10,
+      'text-anchor':  'middle',
+      'font-family':  'Inter, system-ui, sans-serif',
+      'font-size':    11,
+      'font-weight':  700,
+      'letter-spacing': '0.04em',
+      fill: '#000',
+    }, `H${section.heading.level}`));
+
+    // Circle (white fill, black stroke)
+    svgEl_root.appendChild(svgEl('circle', {
+      cx: x, cy: LINE_Y, r: R,
+      fill: '#fff',
+      stroke: '#000',
+      'stroke-width': 2.5,
+    }));
+
+    // Word count below circle
+    svgEl_root.appendChild(svgEl('text', {
+      x, y: LINE_Y + R + 18,
+      'text-anchor':  'middle',
+      'font-family':  'Inter, system-ui, sans-serif',
+      'font-size':    11,
+      'font-weight':  700,
+      fill: color,
+    }, `${section.wordCount} words`));
+
+    // Quality indicator
+    if (section.quality === 'good') {
+      // Fire emoji — good section
+      svgEl_root.appendChild(svgEl('text', {
+        x, y: LINE_Y + R + 36,
+        'text-anchor': 'middle',
+        'font-size':   13,
+      }, '🔥'));
+    } else {
+      // ✕ mark — bad section
+      svgEl_root.appendChild(svgEl('text', {
+        x, y: LINE_Y + R + 36,
+        'text-anchor':  'middle',
+        'font-family':  'Inter, system-ui, sans-serif',
+        'font-size':    14,
+        'font-weight':  900,
+        fill: color,
+      }, '✕'));
+    }
+  }
+}
+
+function qualityColor(quality) {
+  if (quality === 'good')  return COLOR_GOOD;
+  if (quality === 'long')  return COLOR_LONG;
+  if (quality === 'short') return COLOR_SHORT;
+  return COLOR_INTRO;
+}
+
+// ── Section Cards ──────────────────────────────────────────
+/**
+ * Render the section detail cards below the timeline.
+ */
+function renderCards(sections, container) {
+  container.innerHTML = '';
+
+  for (const section of sections) {
+    const card = document.createElement('div');
+    card.className = `section-card section-card--${section.quality}`;
+
+    // Header row
+    const header = document.createElement('div');
+    header.className = 'section-card-header';
+
+    // Left: badge + heading text
+    const titleEl = document.createElement('div');
+    titleEl.className = 'section-card-title';
+
+    const badge = document.createElement('span');
+    badge.className = 'heading-badge' + (section.isIntro ? ' heading-badge--intro' : '');
+    badge.textContent = section.isIntro
+      ? 'INTRO'
+      : `H${section.heading.level}`;
+    titleEl.appendChild(badge);
+
+    if (!section.isIntro) {
+      const headingText = document.createElement('span');
+      headingText.className = 'heading-text';
+      headingText.textContent = section.heading.text;
+      titleEl.appendChild(headingText);
+    }
+
+    header.appendChild(titleEl);
+
+    // Right: word count + quality hint
+    const meta = document.createElement('div');
+    meta.className = 'section-meta';
+
+    const wc = document.createElement('span');
+    wc.className = `word-count word-count--${section.quality}`;
+    wc.textContent = `${section.wordCount} word${section.wordCount !== 1 ? 's' : ''}`;
+    meta.appendChild(wc);
+
+    const hint = document.createElement('span');
+    hint.className = 'quality-hint';
+    hint.textContent = qualityHint(section.quality, section.wordCount);
+    meta.appendChild(hint);
+
+    header.appendChild(meta);
+    card.appendChild(header);
+
+    // Content preview (first ~40 words)
+    if (section.content.trim()) {
+      const words   = section.content.trim().split(/\s+/);
+      const preview = document.createElement('p');
+      preview.className = 'section-preview';
+      preview.textContent = words.slice(0, 40).join(' ') + (words.length > 40 ? ' …' : '');
+      card.appendChild(preview);
+    }
+
+    container.appendChild(card);
+  }
+}
+
+function qualityHint(quality, wordCount) {
+  const diff = TARGET_WORDS - wordCount;
+  if (quality === 'good')  return '🔥 ideal length';
+  if (quality === 'long')  return `✕ too long — aim for ~${TARGET_WORDS} words`;
+  if (quality === 'short') return `✕ too short — consider expanding`;
+  return ''; // intro
+}
+
+// ── No-Headings Message ────────────────────────────────────
+function buildNoHeadingsMessage(totalWords) {
+  const needed = Math.ceil(totalWords / TARGET_WORDS);
+  const div = document.createElement('div');
+  div.className = 'no-headings-msg';
+  div.innerHTML = `
+    <h3>No headings detected</h3>
+    <p>
+      Your text has <strong>${totalWords.toLocaleString()} words</strong> and no markdown headings.<br>
+      For ideal readability, add roughly <strong>${needed} heading${needed !== 1 ? 's' : ''}</strong>
+      — one every ~${TARGET_WORDS} words.<br><br>
+      Markdown syntax: <code># Heading 1</code> &nbsp; <code>## Heading 2</code> &nbsp; <code>### Heading 3</code>
+    </p>
+  `;
+  return div;
+}
+
+// ── Stats Bar ──────────────────────────────────────────────
+function buildStatsBar(stats) {
+  const bar = document.createElement('div');
+  bar.className = 'stats-bar';
+
+  let scoreClass = '';
+  if (stats.score !== null) {
+    scoreClass = stats.score >= 80 ? '' : stats.score >= 50 ? 'score-warn' : 'score-bad';
+  }
+
+  bar.innerHTML = `
+    <span class="stat">
+      <strong>${stats.totalWords.toLocaleString()}</strong> total words
+    </span>
+    <span class="stat">
+      <strong>${stats.headedCount}</strong> section${stats.headedCount !== 1 ? 's' : ''}
+    </span>
+    <span class="stat">
+      Target: <strong>~${TARGET_WORDS} words</strong> per section
+    </span>
+    ${stats.score !== null ? `
+    <span class="stat stat-score ${scoreClass}">
+      Score: <strong>${stats.score}%</strong>
+    </span>` : ''}
+  `;
+
+  return bar;
+}
+
+// ── Main Render ────────────────────────────────────────────
+function render(sections) {
+  const resultsEl = document.getElementById('results');
+  resultsEl.innerHTML = '';
+  resultsEl.hidden = false;
+
+  const stats     = computeStats(sections);
+  const hasHeadings = sections.some(s => !s.isIntro);
+
+  // Stats bar
+  resultsEl.appendChild(buildStatsBar(stats));
+
+  if (!hasHeadings) {
+    // No headings — show advice
+    resultsEl.appendChild(buildNoHeadingsMessage(stats.totalWords));
+  } else {
+    // Timeline
+    const timelineWrap = document.createElement('div');
+    timelineWrap.className = 'timeline-wrap';
+
+    const svg = document.createElementNS(SVG_NS, 'svg');
+    svg.className = 'timeline-svg';
+    svg.setAttribute('role', 'img');
+    svg.setAttribute('aria-label', 'Heading distribution timeline — word counts between headings');
+    timelineWrap.appendChild(svg);
+    resultsEl.appendChild(timelineWrap);
+
+    // Section cards
+    const sectionsTitle = document.createElement('h2');
+    sectionsTitle.className = 'sections-title';
+    sectionsTitle.textContent = 'Sections';
+    resultsEl.appendChild(sectionsTitle);
+
+    const sectionsListEl = document.createElement('div');
+    sectionsListEl.className = 'sections-list';
+    resultsEl.appendChild(sectionsListEl);
+
+    // Draw after layout so we have the correct SVG width
+    requestAnimationFrame(() => {
+      drawTimeline(sections, svg);
+      renderCards(sections, sectionsListEl);
     });
+  }
 
+  resultsEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
 
+// ── Analyze ────────────────────────────────────────────────
+function analyze() {
+  const text = document.getElementById('text-input').value;
 
+  if (!text.trim()) {
+    document.getElementById('text-input').focus();
+    return;
+  }
+
+  const sections = buildSections(text);
+  render(sections);
+}
+
+// ── Clear ──────────────────────────────────────────────────
+function clearAll() {
+  const input     = document.getElementById('text-input');
+  const resultsEl = document.getElementById('results');
+
+  input.value       = '';
+  resultsEl.innerHTML = '';
+  resultsEl.hidden  = true;
+  input.focus();
+}
+
+// ── Redraw on Resize ───────────────────────────────────────
+let resizeTimer = null;
+function onResize() {
+  clearTimeout(resizeTimer);
+  resizeTimer = setTimeout(() => {
+    const svg = document.querySelector('.timeline-svg');
+    if (!svg) return;
+    const text = document.getElementById('text-input').value;
+    if (!text.trim()) return;
+    const sections = buildSections(text);
+    drawTimeline(sections, svg);
+  }, 180);
+}
+
+// ── Event Listeners ────────────────────────────────────────
+document.getElementById('analyze-btn').addEventListener('click', analyze);
+document.getElementById('clear-btn').addEventListener('click', clearAll);
+
+document.getElementById('text-input').addEventListener('keydown', e => {
+  if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+    e.preventDefault();
+    analyze();
+  }
 });
+
+window.addEventListener('resize', onResize);


### PR DESCRIPTION
Complete rewrite of all three files:

- index.html: clean semantic HTML5, no jQuery, no external analytics/tracking,
  keyboard shortcut hint (Ctrl+Enter), accessible aria labels

- css/main.css: full design system matching the mockup — Playfair Display serif
  headings, Inter sans-serif UI, yellow accent button with neo-brutalist shadow,
  colour-coded section cards (green=good, red=long, orange=short), responsive
  layout down to 400px

- js/script.js: complete application logic with zero dependencies
  · parseMarkdown(): parse ## heading syntax into sections
  · countWords() / getQuality(): classify each section (good 150–350w, long, short)
  · drawTimeline(): proportional SVG timeline — circles at heading positions,
    coloured segment overlays, word counts + 🔥/✕ quality indicators below
  · renderCards(): section detail cards with heading badge, word count, preview
  · Stats bar: total words, section count, % score
  · No-headings advice: calculated suggestion for how many headings to add
  · Window resize handler redraws SVG at correct width
  · Ctrl/Cmd+Enter shortcut to run analysis

https://claude.ai/code/session_01NsXiN3wnoMKUZB3Ch5Db79