### PR TITLE
Add text rendering with heading insertion markers

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -487,6 +487,114 @@ footer a:hover {
 }
 
 /* ============================================================
+   TEXT PREVIEW WITH HEADINGS
+   ============================================================ */
+.text-preview-section {
+  margin-top: 2.5rem;
+}
+
+.text-preview {
+  font-family: var(--font-serif);
+  font-size: 1rem;
+  line-height: 1.85;
+  color: var(--c-text);
+}
+
+.text-preview p {
+  margin-bottom: 1.1em;
+}
+
+.preview-intro {
+  color: var(--c-muted);
+  font-style: italic;
+}
+
+/* Heading levels inside the preview */
+h1.preview-heading,
+h2.preview-heading,
+h3.preview-heading,
+h4.preview-heading,
+h5.preview-heading,
+h6.preview-heading {
+  font-family: var(--font-serif);
+  font-weight: 700;
+  line-height: 1.2;
+  margin: 2rem 0 0.75rem;
+  padding-left: 0.85rem;
+  border-left: 3px solid var(--c-text);
+}
+
+h1.preview-heading { font-size: 1.65rem; }
+h2.preview-heading { font-size: 1.3rem;  }
+h3.preview-heading { font-size: 1.1rem;  }
+h4.preview-heading,
+h5.preview-heading,
+h6.preview-heading { font-size: 1rem; font-style: italic; }
+
+.preview-heading--good  { border-left-color: var(--c-good); }
+.preview-heading--long  { border-left-color: var(--c-long); }
+.preview-heading--short { border-left-color: var(--c-short); color: var(--c-short); }
+
+/* ── Insertion marker ── */
+.insertion-marker {
+  display: flex;
+  align-items: center;
+  margin: 1.5rem 0;
+}
+
+.insertion-marker__line {
+  flex: 1;
+  height: 0;
+  border-top: 2px dashed #e5c04e;
+  min-width: 12px;
+}
+
+.insertion-marker__pill {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-shrink: 0;
+  max-width: 78%;
+  overflow: hidden;
+  background: #fffbec;
+  border: 1.5px solid #e5c04e;
+  border-radius: 100px;
+  padding: 0.3rem 0.875rem;
+  font-family: var(--font-sans);
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #7c5f00;
+  white-space: nowrap;
+}
+
+.insertion-marker__icon {
+  flex-shrink: 0;
+  font-size: 0.7em;
+  opacity: 0.8;
+}
+
+.insertion-marker__sentence {
+  font-weight: 400;
+  color: var(--c-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+/* Short section nudge */
+.short-hint {
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  color: var(--c-short);
+  margin: -0.6em 0 1.25em;
+  padding: 0.35rem 0.7rem;
+  background: #fff3eb;
+  border-left: 3px solid var(--c-short);
+  border-radius: 0 2px 2px 0;
+}
+
+/* ============================================================
    RESPONSIVE
    ============================================================ */
 @media (max-width: 560px) {
@@ -512,6 +620,11 @@ footer a:hover {
     flex-direction: row;
     align-items: center;
     gap: 0.5rem;
+  }
+
+  /* Hide the sentence snippet on small screens — just show the pill label */
+  .insertion-marker__sentence {
+    display: none;
   }
 }
 

--- a/js/script.js
+++ b/js/script.js
@@ -7,8 +7,16 @@
    - Parse markdown headings (# ## ### …) from pasted text
    - Count words in each section between headings
    - Visualise sections on a proportional SVG timeline
-   - Colour-code by quality: 🔥 ideal (~250 w), ✕ too long, ✕ too short
-   - Render section cards with heading, word count, and preview
+     · Circles labelled with heading level (H1/H2/H3…)
+     · Coloured segments proportional to word counts
+     · 🔥 ideal / ✕ too long / ✕ too short quality indicators
+     · First-sentence snippet under each marker for quick context
+   - Section detail cards with word count + content preview
+   - Full document renderer with:
+     · Existing headings styled by level
+     · ✦ insertion markers showing where to split long sections
+     · First sentence of each new chunk shown as context
+     · Auto-split for documents with no headings at all
    ============================================================ */
 
 // ── Constants ──────────────────────────────────────────────
@@ -61,16 +69,12 @@ function parseMarkdown(text) {
 }
 
 // ── Word Counting & Quality ────────────────────────────────
-/**
- * Count words in a string.
- */
 function countWords(str) {
   if (!str.trim()) return 0;
   return str.trim().split(/\s+/).length;
 }
 
 /**
- * Return quality tier for a word count.
  * @returns {'good'|'long'|'short'|'intro'}
  */
 function getQuality(wordCount, isIntro) {
@@ -81,14 +85,11 @@ function getQuality(wordCount, isIntro) {
 }
 
 // ── Build Processed Sections ───────────────────────────────
-/**
- * Build a processed sections array with word counts and quality tiers.
- */
 function buildSections(text) {
   const raw = parseMarkdown(text);
 
   return raw
-    .map((s, i) => {
+    .map(s => {
       const wordCount = countWords(s.content);
       const isIntro   = s.heading === null;
       return {
@@ -99,115 +100,178 @@ function buildSections(text) {
         isIntro,
       };
     })
-    // Drop completely empty intro (nothing before first heading)
     .filter(s => s.heading !== null || s.wordCount > 0);
 }
 
 // ── Stats ──────────────────────────────────────────────────
 function computeStats(sections) {
-  const totalWords      = sections.reduce((n, s) => n + s.wordCount, 0);
-  const headedSections  = sections.filter(s => !s.isIntro);
-  const goodCount       = headedSections.filter(s => s.quality === 'good').length;
-  const score           = headedSections.length > 0
+  const totalWords     = sections.reduce((n, s) => n + s.wordCount, 0);
+  const headedSections = sections.filter(s => !s.isIntro);
+  const goodCount      = headedSections.filter(s => s.quality === 'good').length;
+  const score          = headedSections.length > 0
     ? Math.round((goodCount / headedSections.length) * 100)
     : null;
 
-  return {
-    totalWords,
-    headedCount:  headedSections.length,
-    totalCount:   sections.length,
-    score,
-    goodCount,
-  };
+  return { totalWords, headedCount: headedSections.length, totalCount: sections.length, score };
 }
 
 // ── SVG Helpers ────────────────────────────────────────────
 function svgEl(tag, attrs, text) {
   const e = document.createElementNS(SVG_NS, tag);
-  if (attrs) {
-    for (const [k, v] of Object.entries(attrs)) {
-      e.setAttribute(k, String(v));
-    }
-  }
+  if (attrs) for (const [k, v] of Object.entries(attrs)) e.setAttribute(k, String(v));
   if (text != null) e.textContent = String(text);
   return e;
+}
+
+// ── Text Utilities ─────────────────────────────────────────
+/**
+ * Return the first sentence of text, capped at maxChars.
+ * Falls back to first N words if no sentence break is found.
+ */
+function firstSentenceSnippet(text, maxChars) {
+  const t = text.trim().replace(/\n/g, ' ');
+  const m = t.match(/^.+?[.!?]["'»]?\s/);
+  const sentence = m ? m[0].trim() : t.split(/\s+/).slice(0, 9).join(' ');
+  return sentence.length > maxChars ? sentence.slice(0, maxChars - 1) + '…' : sentence;
+}
+
+/**
+ * Find the best word-index split near targetIdx — prefers a sentence boundary
+ * (ends with . ! ?) within ±25 words of the target.
+ */
+function findSplitIndex(words, targetIdx) {
+  for (let i = targetIdx; i < Math.min(targetIdx + 25, words.length - 1); i++) {
+    if (/[.!?]["'»]?$/.test(words[i])) return i + 1;
+  }
+  for (let i = targetIdx - 1; i >= Math.max(targetIdx - 25, 0); i--) {
+    if (/[.!?]["'»]?$/.test(words[i])) return i + 1;
+  }
+  return targetIdx;
+}
+
+/**
+ * Recursively split text into chunks where each chunk is ≤ MAX_OK words,
+ * breaking preferentially at sentence boundaries near TARGET_WORDS.
+ */
+function chunkText(text) {
+  const words = text.trim().split(/\s+/).filter(Boolean);
+  if (words.length <= MAX_OK) return [words.join(' ')];
+
+  const splitAt = findSplitIndex(words, TARGET_WORDS);
+  const head = words.slice(0, splitAt).join(' ');
+  const tail = words.slice(splitAt).join(' ');
+  return [head, ...chunkText(tail)];
+}
+
+/** Escape HTML special chars for safe innerHTML insertion. */
+function esc(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Append <p> elements from a block of text to container.
+ * Splits on double newlines; single newlines within a block become spaces.
+ */
+function appendParas(container, text, extraClass = '') {
+  const blocks = text.split(/\n\n+/)
+    .map(b => b.replace(/\n/g, ' ').trim())
+    .filter(Boolean);
+
+  const items = blocks.length > 0 ? blocks : [text.replace(/\n/g, ' ').trim()];
+
+  for (const block of items) {
+    if (!block) continue;
+    const p = document.createElement('p');
+    if (extraClass) p.className = extraClass;
+    p.textContent = block;
+    container.appendChild(p);
+  }
+}
+
+/** Build a ✦ insertion marker pill showing the first sentence of nextChunkText. */
+function buildInsertionMarker(nextChunkText) {
+  const snippet = firstSentenceSnippet(nextChunkText, 72);
+  const div = document.createElement('div');
+  div.className = 'insertion-marker';
+  div.innerHTML = `
+    <span class="insertion-marker__line"></span>
+    <span class="insertion-marker__pill">
+      <span class="insertion-marker__icon" aria-hidden="true">✦</span>
+      <span>Add heading here</span>
+      <span class="insertion-marker__sentence">— "<em>${esc(snippet)}</em>"</span>
+    </span>
+    <span class="insertion-marker__line"></span>
+  `;
+  return div;
 }
 
 // ── Timeline ───────────────────────────────────────────────
 /**
  * Draw the proportional SVG timeline.
  *
- * Layout (per headed section):
- *   [H2]   ← heading level label (above line)
- *    ○     ← circle marker on line (at START of section)
- *  250w    ← word count (below line, coloured)
- *   🔥     ← quality indicator
- *
- * Spacing between circles is proportional to word count of each section.
+ * Per headed section (from left to right, proportional to word count):
+ *   [H2]           ← heading level label
+ *    ○             ← circle at START of section
+ *  250 words       ← word count, colour-coded
+ *   🔥             ← quality indicator
+ *  "First few…"   ← first-sentence snippet (context)
  */
 function drawTimeline(sections, svgEl_root) {
   svgEl_root.innerHTML = '';
 
-  const totalWords    = sections.reduce((n, s) => n + s.wordCount, 0);
-  const headedSects   = sections.filter(s => !s.isIntro);
+  const totalWords  = sections.reduce((n, s) => n + s.wordCount, 0);
+  const headedSects = sections.filter(s => !s.isIntro);
   if (totalWords === 0 || headedSects.length === 0) return;
 
-  // Dimensions
   const containerW = svgEl_root.getBoundingClientRect().width || 680;
-  const PAD_L      = 50;
-  const PAD_R      = 50;
-  const LINE_W     = containerW - PAD_L - PAD_R;
-  const LINE_Y     = 68;
-  const SVG_H      = 155;
-  const R          = 15;  // circle radius
+  const PAD_L = 50;
+  const PAD_R = 50;
+  const LINE_W = containerW - PAD_L - PAD_R;
+  const LINE_Y = 68;
+  const SVG_H  = 195;
+  const R      = 15;
 
   svgEl_root.setAttribute('viewBox', `0 0 ${containerW} ${SVG_H}`);
   svgEl_root.style.height = `${SVG_H}px`;
 
-  // ── Build position data ──
-  // Circle x = cumulative words BEFORE this section (proportional to total)
+  // ── Position data: circle at start of each section ──
   let cumWords = 0;
   const positioned = sections.map(section => {
-    const x     = PAD_L + (cumWords / totalWords) * LINE_W;
-    const endX  = PAD_L + ((cumWords + section.wordCount) / totalWords) * LINE_W;
-    cumWords   += section.wordCount;
+    const x    = PAD_L + (cumWords / totalWords) * LINE_W;
+    const endX = PAD_L + ((cumWords + section.wordCount) / totalWords) * LINE_W;
+    cumWords  += section.wordCount;
     return { section, x, endX };
   });
 
-  // ── Base grey line ──
+  // Base grey line
   svgEl_root.appendChild(svgEl('line', {
     x1: PAD_L, y1: LINE_Y,
     x2: PAD_L + LINE_W, y2: LINE_Y,
-    stroke: '#ccc',
-    'stroke-width': 6,
-    'stroke-linecap': 'round',
+    stroke: '#ccc', 'stroke-width': 6, 'stroke-linecap': 'round',
   }));
 
-  // ── Coloured segment overlays (per section) ──
+  // Coloured segment overlays
   for (const { section, x, endX } of positioned) {
     if (section.isIntro || endX - x < 1) continue;
-    const color = qualityColor(section.quality);
     svgEl_root.appendChild(svgEl('line', {
-      x1: x,    y1: LINE_Y,
-      x2: endX, y2: LINE_Y,
-      stroke: color,
-      'stroke-width': 6,
-      'stroke-linecap': 'butt',
-      opacity: 0.35,
+      x1: x, y1: LINE_Y, x2: endX, y2: LINE_Y,
+      stroke: qualityColor(section.quality),
+      'stroke-width': 6, 'stroke-linecap': 'butt', opacity: 0.35,
     }));
   }
 
-  // ── Black hairline on top ──
+  // Black hairline on top
   svgEl_root.appendChild(svgEl('line', {
     x1: PAD_L, y1: LINE_Y,
     x2: PAD_L + LINE_W, y2: LINE_Y,
-    stroke: '#000',
-    'stroke-width': 3,
-    'stroke-linecap': 'round',
-    opacity: 0.18,
+    stroke: '#000', 'stroke-width': 3, 'stroke-linecap': 'round', opacity: 0.18,
   }));
 
-  // ── Heading markers ──
+  // Heading markers
   for (const { section, x } of positioned) {
     if (section.isIntro) continue;
 
@@ -216,50 +280,44 @@ function drawTimeline(sections, svgEl_root) {
     // Heading level label above circle
     svgEl_root.appendChild(svgEl('text', {
       x, y: LINE_Y - R - 10,
-      'text-anchor':  'middle',
-      'font-family':  'Inter, system-ui, sans-serif',
-      'font-size':    11,
-      'font-weight':  700,
-      'letter-spacing': '0.04em',
-      fill: '#000',
+      'text-anchor': 'middle', 'font-family': 'Inter, system-ui, sans-serif',
+      'font-size': 11, 'font-weight': 700, 'letter-spacing': '0.04em', fill: '#000',
     }, `H${section.heading.level}`));
 
-    // Circle (white fill, black stroke)
+    // Circle
     svgEl_root.appendChild(svgEl('circle', {
       cx: x, cy: LINE_Y, r: R,
-      fill: '#fff',
-      stroke: '#000',
-      'stroke-width': 2.5,
+      fill: '#fff', stroke: '#000', 'stroke-width': 2.5,
     }));
 
-    // Word count below circle
+    // Word count
     svgEl_root.appendChild(svgEl('text', {
       x, y: LINE_Y + R + 18,
-      'text-anchor':  'middle',
-      'font-family':  'Inter, system-ui, sans-serif',
-      'font-size':    11,
-      'font-weight':  700,
-      fill: color,
+      'text-anchor': 'middle', 'font-family': 'Inter, system-ui, sans-serif',
+      'font-size': 11, 'font-weight': 700, fill: color,
     }, `${section.wordCount} words`));
 
     // Quality indicator
     if (section.quality === 'good') {
-      // Fire emoji — good section
       svgEl_root.appendChild(svgEl('text', {
-        x, y: LINE_Y + R + 36,
-        'text-anchor': 'middle',
-        'font-size':   13,
+        x, y: LINE_Y + R + 36, 'text-anchor': 'middle', 'font-size': 13,
       }, '🔥'));
     } else {
-      // ✕ mark — bad section
       svgEl_root.appendChild(svgEl('text', {
         x, y: LINE_Y + R + 36,
-        'text-anchor':  'middle',
-        'font-family':  'Inter, system-ui, sans-serif',
-        'font-size':    14,
-        'font-weight':  900,
-        fill: color,
+        'text-anchor': 'middle', 'font-family': 'Inter, system-ui, sans-serif',
+        'font-size': 14, 'font-weight': 900, fill: color,
       }, '✕'));
+    }
+
+    // First-sentence snippet (context beneath the indicator)
+    if (section.content.trim()) {
+      const snippet = firstSentenceSnippet(section.content, 36);
+      svgEl_root.appendChild(svgEl('text', {
+        x, y: LINE_Y + R + 54,
+        'text-anchor': 'middle', 'font-family': 'Inter, system-ui, sans-serif',
+        'font-size': 9, 'font-style': 'italic', fill: '#bbb',
+      }, snippet));
     }
   }
 }
@@ -271,10 +329,72 @@ function qualityColor(quality) {
   return COLOR_INTRO;
 }
 
-// ── Section Cards ──────────────────────────────────────────
+// ── Text With Headings Renderer ─────────────────────────────
 /**
- * Render the section detail cards below the timeline.
+ * Render the full document:
+ * - Existing headings styled as <h1>–<h6>
+ * - Long sections split with ✦ insertion markers showing first sentence of each chunk
+ * - Short sections flagged with a gentle hint
+ * - No-headings case: auto-split entire text at ~TARGET_WORDS intervals
  */
+function renderTextWithHeadings(sections) {
+  const wrap = document.createElement('div');
+  wrap.className = 'text-preview';
+
+  const hasHeadings = sections.some(s => !s.isIntro);
+
+  if (!hasHeadings) {
+    // Auto-split full text and show where headings should go
+    const fullText = sections.map(s => s.content).join('\n\n');
+    const chunks = chunkText(fullText);
+    chunks.forEach((chunk, i) => {
+      appendParas(wrap, chunk);
+      if (i < chunks.length - 1) {
+        wrap.appendChild(buildInsertionMarker(chunks[i + 1]));
+      }
+    });
+    return wrap;
+  }
+
+  for (const section of sections) {
+    // Styled heading
+    if (section.heading) {
+      const level = Math.min(section.heading.level, 6);
+      const h = document.createElement(`h${level}`);
+      h.className = `preview-heading preview-heading--${section.quality}`;
+      h.textContent = section.heading.text;
+      wrap.appendChild(h);
+    }
+
+    const text = section.content.trim();
+    if (!text) continue;
+
+    if (section.quality === 'long') {
+      // Split and interleave insertion markers
+      const chunks = chunkText(text);
+      chunks.forEach((chunk, i) => {
+        appendParas(wrap, chunk, section.isIntro ? 'preview-intro' : '');
+        if (i < chunks.length - 1) {
+          wrap.appendChild(buildInsertionMarker(chunks[i + 1]));
+        }
+      });
+    } else {
+      appendParas(wrap, text, section.isIntro ? 'preview-intro' : '');
+    }
+
+    // Gentle nudge for short sections
+    if (section.quality === 'short' && !section.isIntro) {
+      const hint = document.createElement('p');
+      hint.className = 'short-hint';
+      hint.textContent = '↕ Section is short — consider expanding or merging with the next section';
+      wrap.appendChild(hint);
+    }
+  }
+
+  return wrap;
+}
+
+// ── Section Cards ──────────────────────────────────────────
 function renderCards(sections, container) {
   container.innerHTML = '';
 
@@ -282,31 +402,26 @@ function renderCards(sections, container) {
     const card = document.createElement('div');
     card.className = `section-card section-card--${section.quality}`;
 
-    // Header row
     const header = document.createElement('div');
     header.className = 'section-card-header';
 
-    // Left: badge + heading text
     const titleEl = document.createElement('div');
     titleEl.className = 'section-card-title';
 
     const badge = document.createElement('span');
     badge.className = 'heading-badge' + (section.isIntro ? ' heading-badge--intro' : '');
-    badge.textContent = section.isIntro
-      ? 'INTRO'
-      : `H${section.heading.level}`;
+    badge.textContent = section.isIntro ? 'INTRO' : `H${section.heading.level}`;
     titleEl.appendChild(badge);
 
     if (!section.isIntro) {
-      const headingText = document.createElement('span');
-      headingText.className = 'heading-text';
-      headingText.textContent = section.heading.text;
-      titleEl.appendChild(headingText);
+      const ht = document.createElement('span');
+      ht.className = 'heading-text';
+      ht.textContent = section.heading.text;
+      titleEl.appendChild(ht);
     }
 
     header.appendChild(titleEl);
 
-    // Right: word count + quality hint
     const meta = document.createElement('div');
     meta.className = 'section-meta';
 
@@ -317,15 +432,14 @@ function renderCards(sections, container) {
 
     const hint = document.createElement('span');
     hint.className = 'quality-hint';
-    hint.textContent = qualityHint(section.quality, section.wordCount);
+    hint.textContent = qualityHint(section.quality);
     meta.appendChild(hint);
 
     header.appendChild(meta);
     card.appendChild(header);
 
-    // Content preview (first ~40 words)
     if (section.content.trim()) {
-      const words   = section.content.trim().split(/\s+/);
+      const words = section.content.trim().split(/\s+/);
       const preview = document.createElement('p');
       preview.className = 'section-preview';
       preview.textContent = words.slice(0, 40).join(' ') + (words.length > 40 ? ' …' : '');
@@ -336,15 +450,14 @@ function renderCards(sections, container) {
   }
 }
 
-function qualityHint(quality, wordCount) {
-  const diff = TARGET_WORDS - wordCount;
-  if (quality === 'good')  return '🔥 ideal length';
+function qualityHint(quality) {
+  if (quality === 'good')  return `🔥 ideal length`;
   if (quality === 'long')  return `✕ too long — aim for ~${TARGET_WORDS} words`;
   if (quality === 'short') return `✕ too short — consider expanding`;
-  return ''; // intro
+  return '';
 }
 
-// ── No-Headings Message ────────────────────────────────────
+// ── No-Headings Notice ─────────────────────────────────────
 function buildNoHeadingsMessage(totalWords) {
   const needed = Math.ceil(totalWords / TARGET_WORDS);
   const div = document.createElement('div');
@@ -366,27 +479,17 @@ function buildStatsBar(stats) {
   const bar = document.createElement('div');
   bar.className = 'stats-bar';
 
-  let scoreClass = '';
-  if (stats.score !== null) {
-    scoreClass = stats.score >= 80 ? '' : stats.score >= 50 ? 'score-warn' : 'score-bad';
-  }
+  const scoreClass = stats.score === null ? ''
+    : stats.score >= 80 ? '' : stats.score >= 50 ? 'score-warn' : 'score-bad';
 
   bar.innerHTML = `
-    <span class="stat">
-      <strong>${stats.totalWords.toLocaleString()}</strong> total words
-    </span>
-    <span class="stat">
-      <strong>${stats.headedCount}</strong> section${stats.headedCount !== 1 ? 's' : ''}
-    </span>
-    <span class="stat">
-      Target: <strong>~${TARGET_WORDS} words</strong> per section
-    </span>
-    ${stats.score !== null ? `
-    <span class="stat stat-score ${scoreClass}">
-      Score: <strong>${stats.score}%</strong>
-    </span>` : ''}
+    <span class="stat"><strong>${stats.totalWords.toLocaleString()}</strong> total words</span>
+    <span class="stat"><strong>${stats.headedCount}</strong> section${stats.headedCount !== 1 ? 's' : ''}</span>
+    <span class="stat">Target: <strong>~${TARGET_WORDS} words</strong> per section</span>
+    ${stats.score !== null
+      ? `<span class="stat stat-score ${scoreClass}">Score: <strong>${stats.score}%</strong></span>`
+      : ''}
   `;
-
   return bar;
 }
 
@@ -396,14 +499,14 @@ function render(sections) {
   resultsEl.innerHTML = '';
   resultsEl.hidden = false;
 
-  const stats     = computeStats(sections);
+  const stats       = computeStats(sections);
   const hasHeadings = sections.some(s => !s.isIntro);
 
-  // Stats bar
+  // Stats bar (always)
   resultsEl.appendChild(buildStatsBar(stats));
 
   if (!hasHeadings) {
-    // No headings — show advice
+    // No headings — show advice notice
     resultsEl.appendChild(buildNoHeadingsMessage(stats.totalWords));
   } else {
     // Timeline
@@ -427,12 +530,25 @@ function render(sections) {
     sectionsListEl.className = 'sections-list';
     resultsEl.appendChild(sectionsListEl);
 
-    // Draw after layout so we have the correct SVG width
     requestAnimationFrame(() => {
       drawTimeline(sections, svg);
       renderCards(sections, sectionsListEl);
     });
   }
+
+  // ── Text with headings (always shown) ──
+  const previewSection = document.createElement('div');
+  previewSection.className = 'text-preview-section';
+
+  const previewTitle = document.createElement('h2');
+  previewTitle.className = 'sections-title';
+  previewTitle.textContent = hasHeadings
+    ? 'Your text — with suggested structure'
+    : 'Your text — with suggested heading positions';
+  previewSection.appendChild(previewTitle);
+
+  previewSection.appendChild(renderTextWithHeadings(sections));
+  resultsEl.appendChild(previewSection);
 
   resultsEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
@@ -440,38 +556,32 @@ function render(sections) {
 // ── Analyze ────────────────────────────────────────────────
 function analyze() {
   const text = document.getElementById('text-input').value;
-
   if (!text.trim()) {
     document.getElementById('text-input').focus();
     return;
   }
-
-  const sections = buildSections(text);
-  render(sections);
+  render(buildSections(text));
 }
 
 // ── Clear ──────────────────────────────────────────────────
 function clearAll() {
   const input     = document.getElementById('text-input');
   const resultsEl = document.getElementById('results');
-
   input.value       = '';
   resultsEl.innerHTML = '';
   resultsEl.hidden  = true;
   input.focus();
 }
 
-// ── Redraw on Resize ───────────────────────────────────────
+// ── Resize ─────────────────────────────────────────────────
 let resizeTimer = null;
 function onResize() {
   clearTimeout(resizeTimer);
   resizeTimer = setTimeout(() => {
-    const svg = document.querySelector('.timeline-svg');
-    if (!svg) return;
+    const svg  = document.querySelector('.timeline-svg');
     const text = document.getElementById('text-input').value;
-    if (!text.trim()) return;
-    const sections = buildSections(text);
-    drawTimeline(sections, svg);
+    if (!svg || !text.trim()) return;
+    drawTimeline(buildSections(text), svg);
   }, 180);
 }
 


### PR DESCRIPTION
Timeline:
- Increase SVG height to 195px to accommodate new content
- Add first-sentence snippet (italic grey text) under each circle marker so writers can identify sections at a glance without reading the cards

Text preview section (always shown below the section cards):
- Renders the full document with headings styled as h1–h6 elements, left-border colour-coded by quality (green/red/orange)
- Long sections (>350w) are auto-split at ~250-word sentence boundaries; each split point shows a dashed ✦ insertion marker pill with the first sentence of the new chunk: "Add heading here — 'First sentence…'"
- Short sections show a subtle orange hint bar
- No-headings case: auto-splits the entire text every ~250 words and places insertion markers throughout, giving writers a concrete map of where headings should go

Text splitting logic:
- chunkText() recursively splits at sentence boundaries (±25 words) to avoid cutting mid-sentence
- firstSentenceSnippet() extracts context for both timeline snippets and insertion marker pills

https://claude.ai/code/session_01NsXiN3wnoMKUZB3Ch5Db79